### PR TITLE
Fix Relation Graph in Chrome

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_AXIOS_URL = http://ec2-18-134-210-210.eu-west-2.compute.amazonaws.com/api
+REACT_APP_AXIOS_URL = https://blue.bicikl-project.eu/api

--- a/dockerfile
+++ b/dockerfile
@@ -25,6 +25,3 @@ COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose port
 EXPOSE 3000
-
-# # Start application
-# CMD ["nginx", "-g", "daemon off;"]

--- a/src/templates/home/Home.js
+++ b/src/templates/home/Home.js
@@ -18,6 +18,7 @@ const Home = () => {
     const navigate = useNavigate();
 
     const [searching, setSearching] = useState(false);
+    const [errorMessage, setErrorMessage] = useState();
 
     /* Get Interaction Types */
     const [interactionTypes, setInteractionTypes] = useState([]);
@@ -57,11 +58,12 @@ const Home = () => {
             setSearching(true);
 
             formData['interactionType'] = formData['interaction'].substring(0, formData['interaction'].indexOf(","));
+
             formData['interaction'] = formData['interaction'].split(',')[1];
 
             if (formData['taxonB'].length > 0) {
                 const request_body = {
-                    relation: formData['interaction'],
+                    relation: formData['interactionType'],
                     is_subject: true,
                     taxon_id: formData['taxonA'],
                     check: formData['taxonB'],
@@ -81,6 +83,9 @@ const Home = () => {
                             formData: formData
                         }
                     });
+                } else {
+                    setSearching(false);
+                    setErrorMessage('Something went wrong, please try again')
                 }
             }
         }
@@ -96,6 +101,7 @@ const Home = () => {
                         <QueryForm searching={searching}
                             interactionTypes={interactionTypes}
                             formIndication={formIndication}
+                            errorMessage={errorMessage}
 
                             SubmitForm={(formData) => SubmitForm(formData)}
                             SetSearching={() => setSearching(true)}

--- a/src/templates/home/Home.js
+++ b/src/templates/home/Home.js
@@ -56,6 +56,9 @@ const Home = () => {
         if (CheckForm(formData)) {
             setSearching(true);
 
+            formData['interactionType'] = formData['interaction'].substring(0, formData['interaction'].indexOf(","));
+            formData['interaction'] = formData['interaction'].split(',')[1];
+
             if (formData['taxonB'].length > 0) {
                 const request_body = {
                     relation: formData['interaction'],
@@ -78,8 +81,6 @@ const Home = () => {
                             formData: formData
                         }
                     });
-                } else {
-                    console.log(result);
                 }
             }
         }

--- a/src/templates/home/components/queryForm/QueryForm.js
+++ b/src/templates/home/components/queryForm/QueryForm.js
@@ -6,15 +6,13 @@ const QueryForm = (props) => {
     const { formIndication, interactionTypes } = props;
 
     /* Function for rendering the Interaction Types as select options */
-    function RenderInteractionOptions(setInteractionType) {
+    function RenderInteractionOptions() {
         const interactionOptions = [];
 
         Object.entries(interactionTypes).forEach((interactionTypeList) => {
             interactionTypeList[1].forEach((interactionType, i) => {
                 interactionOptions.push(
-                    <option key={interactionTypeList[0] + i} value={interactionType[0]}
-                        onClick={() => setInteractionType(interactionTypeList[0])}
-                    >
+                    <option key={interactionTypeList[0] + i} value={[interactionTypeList[0], interactionType[0]]}>
                         {interactionType[1]}
                     </option>
                 );
@@ -57,23 +55,38 @@ const QueryForm = (props) => {
                 </Row>
                 <Row className="mt-4">
                     <Col md={{ span: 4 }}>
-                        Taxon 1
+                        <div data-bs-toggle="tooltip" data-bs-placement="top"
+                            title="Use this field to define a base taxon whose interactions will be checked based upon the chosen 
+                            interaction method (and possible other taxa)"
+                        >
+                            Taxon 1
+                        </div>
                     </Col>
                     <Col md={{ span: 4 }}>
-                        Interaction
+                        <div data-bs-toggle="tooltip" data-bs-placement="top"
+                            title="Choose an option from this list to define an interaction method that will be used to search for interaction 
+                            related taxa (or to compare to the optional taxa)"
+                        >
+                            Interaction
+                        </div>
                     </Col>
                     <Col md={{ span: 4 }}>
-                        Compare to taxa (optional)
+                        <div data-bs-toggle="tooltip" data-bs-placement="top"
+                            title="Use this optional field to define taxa that will be checked against the base taxon using the chosen interaction 
+                            method (only taxa defined in this field will be taken into account in the results screen). Add by using the + button"
+                        >
+                            Compare to taxa (optional)
+                        </div>
                     </Col>
                 </Row>
                 <Formik
                     initialValues={{
                         taxonA: "",
                         interaction: '',
-                        interactionType: '',
                         dummyTaxon: "",
                         taxonB: []
                     }}
+                    enableReinitialize
                     onSubmit={async (values) => {
                         await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -86,6 +99,7 @@ const QueryForm = (props) => {
                                 <Col md={{ span: 4 }} className="position-relative justify-content-center d-flex">
                                     <Field name="taxonA" type="text"
                                         className="home_queryFormField w-100 px-1"
+                                        placeholder="1314881"
                                     />
 
                                     <div className={`home_queryFormWarning ${formIndication} w-75 text-center fw-bold p-1`}> Please insert a taxon id </div>
@@ -98,8 +112,10 @@ const QueryForm = (props) => {
                                             Choose interaction
                                         </option>
 
-                                        {RenderInteractionOptions((interactionType) => { console.log('test'); values.interactionType = interactionType })}
+                                        {RenderInteractionOptions()}
                                     </Field>
+
+                                    <Field name="interactionType" type="hidden" value="pollinates" />
                                 </Col>
                                 <Col md={{ span: 4 }}>
                                     <FieldArray name="taxonB">
@@ -109,6 +125,7 @@ const QueryForm = (props) => {
                                                     <Col className="pe-0">
                                                         <Field className="home_queryFormField taxonB w-100 px-1"
                                                             name="dummyTaxon"
+                                                            placeholder="2928234"
                                                         />
                                                     </Col>
                                                     <Col className="col-md-auto p-0">
@@ -157,7 +174,7 @@ const QueryForm = (props) => {
                     )}
                 </Formik>
             </Col>
-        </Row>
+        </Row >
     );
 }
 

--- a/src/templates/home/components/queryForm/QueryForm.js
+++ b/src/templates/home/components/queryForm/QueryForm.js
@@ -3,7 +3,7 @@ import { Row, Col } from 'react-bootstrap';
 
 
 const QueryForm = (props) => {
-    const { formIndication, interactionTypes } = props;
+    const { formIndication, interactionTypes, errorMessage } = props;
 
     /* Function for rendering the Interaction Types as select options */
     function RenderInteractionOptions() {
@@ -82,7 +82,7 @@ const QueryForm = (props) => {
                 <Formik
                     initialValues={{
                         taxonA: "",
-                        interaction: '',
+                        interaction: 'pollinates,pollinatedBy',
                         dummyTaxon: "",
                         taxonB: []
                     }}
@@ -173,6 +173,14 @@ const QueryForm = (props) => {
                         </Form>
                     )}
                 </Formik>
+
+                {errorMessage &&
+                    <Row className="mt-4">
+                        <Col className="text-center text-danger">
+                            {errorMessage}
+                        </Col>
+                    </Row>
+                }
             </Col>
         </Row >
     );

--- a/src/templates/results/components/GraphLayout.js
+++ b/src/templates/results/components/GraphLayout.js
@@ -8,8 +8,7 @@ import GetInteractions from 'api/interactions/GetInteractions';
 
 
 const GraphLayout = (props) => {
-    const results = props.results;
-    const formData = props.formData;
+    const {results, formData} = props;
 
     const targetTaxon = results['Input'][0];
 

--- a/src/templates/results/components/ResultsBody.js
+++ b/src/templates/results/components/ResultsBody.js
@@ -90,7 +90,7 @@ const ResultsBody = (props) => {
                     <Col md={{ span: 10, offset: 1 }} className="h-100">
                         <Row className="mt-5">
                             <Col className="fw-bold">
-                                {`Results / ${formData['interactionType']}`}
+                                {`Results / ${formData['interaction']}`}
                             </Col>
                             <Col className="col-md-auto">
                                 <Row>


### PR DESCRIPTION
Commit fixes the bug that caused the relation graph in Chrome to not extend upon existing nodes. The issue originated in the query form component because it did not update the interaction type variable. This was caused by Chrome not supporting onclick events for select options, instead use onchange on the select element.